### PR TITLE
fix: `I18n.locale` Changes in Controller Leaks to Other Threads

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,11 +1,4 @@
 class PagesController < ApplicationController
-
-  before_action :set_locale
-
-  private def set_locale
-    I18n.locale = params[:locale] || "en"
-  end
-
   def privacy
     set_cache_control_headers
     @content = set_content("privacy")


### PR DESCRIPTION
## Problem

The `I18n.locale` was being changed in the controller while the tests were running in parallel, affecting other tests.

Therefore, depending on the combination of tests being executed in parallel, the tests could fail.

## How to fix it

According to the official documentation, `I18n.locale_with` should have been used for the purpose of switching locale per request.

**See also**

- https://guides.rubyonrails.org/i18n.html#managing-the-locale-across-requests